### PR TITLE
Add GetFreePorts

### DIFF
--- a/freeport.go
+++ b/freeport.go
@@ -28,3 +28,22 @@ func GetPort() int {
 	}
 	return port
 }
+
+// GetFreePort asks the kernel for free open ports that are ready to use.
+func GetFreePorts(count int) ([]int, error) {
+	var ports []int
+	for i := 0; i < count; i++ {
+		addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+		if err != nil {
+			return nil, err
+		}
+
+		l, err := net.ListenTCP("tcp", addr)
+		if err != nil {
+			return nil, err
+		}
+		defer l.Close()
+		ports = append(ports, l.Addr().(*net.TCPAddr).Port)
+	}
+	return ports, nil
+}

--- a/freeport_test.go
+++ b/freeport_test.go
@@ -22,3 +22,26 @@ func TestGetFreePort(t *testing.T) {
 	}
 	defer l.Close()
 }
+
+func TestGetFreePorts(t *testing.T) {
+	count := 3
+	ports, err := GetFreePorts(count)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(ports) == 0 {
+		t.Error("len(ports) == 0")
+	}
+	for _, port := range ports {
+		if port == 0 {
+			t.Error("port == 0")
+		}
+
+		// Try to listen on the port
+		l, err := net.Listen("tcp", "localhost"+":"+strconv.Itoa(port))
+		if err != nil {
+			t.Error(err)
+		}
+		defer l.Close()
+	}
+}


### PR DESCRIPTION
Hi, first of all, thanks for a nice library!

This pull request adds `GetFreePorts` which returns free ports of the specified count.
I need this feature to test a server that listens on multiple TCP ports.

Could you review this?
Thanks!