### PR TITLE
Add UDP support

### DIFF
--- a/freeport.go
+++ b/freeport.go
@@ -5,7 +5,12 @@ import (
 )
 
 // GetFreePort asks the kernel for a free open port that is ready to use.
-func GetFreePort(protocol string) (int, error) {
+func GetFreePort() (int, error) {
+	return getFreePortTCP()
+}
+
+// GetFreePortForProtocol asks the kernel for a free open port that is ready to use.
+func GetFreePortForProtocol(protocol string) (int, error) {
 	if protocol == "udp" {
 		return getFreePortUDP()
 	}
@@ -52,7 +57,12 @@ func GetPort() int {
 }
 
 // GetFreePorts asks the kernel for free open ports that are ready to use.
-func GetFreePorts(protocol string, count int) ([]int, error) {
+func GetFreePorts(count int) ([]int, error) {
+	return getFreePortsTCP(count)
+}
+
+// GetFreePortsForProtocol asks the kernel for free open ports that are ready to use.
+func GetFreePortsForProtocol(protocol string, count int) ([]int, error) {
 	if protocol == "udp" {
 		return getFreePortsUDP(count)
 	}

--- a/freeport_test.go
+++ b/freeport_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestGetFreePortTCP(t *testing.T) {
-	port, err := GetFreePort("tcp")
+	port, err := GetFreePortForProtocol("tcp")
 	if err != nil {
 		t.Error(err)
 	}
@@ -24,7 +24,7 @@ func TestGetFreePortTCP(t *testing.T) {
 }
 
 func TestGetFreePortUDP(t *testing.T) {
-	port, err := GetFreePort("udp")
+	port, err := GetFreePortForProtocol("udp")
 	if err != nil {
 		t.Error(err)
 	}
@@ -42,7 +42,7 @@ func TestGetFreePortUDP(t *testing.T) {
 
 func TestGetFreePortsTCP(t *testing.T) {
 	count := 3
-	ports, err := GetFreePorts("tcp", count)
+	ports, err := GetFreePortsForProtocol("tcp", count)
 	if err != nil {
 		t.Error(err)
 	}
@@ -65,7 +65,7 @@ func TestGetFreePortsTCP(t *testing.T) {
 
 func TestGetFreePortsUDP(t *testing.T) {
 	count := 3
-	ports, err := GetFreePorts("udp", count)
+	ports, err := GetFreePortsForProtocol("udp", count)
 	if err != nil {
 		t.Error(err)
 	}

--- a/freeport_test.go
+++ b/freeport_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 )
 
-func TestGetFreePort(t *testing.T) {
-	port, err := GetFreePort()
+func TestGetFreePortTCP(t *testing.T) {
+	port, err := GetFreePort("tcp")
 	if err != nil {
 		t.Error(err)
 	}
@@ -23,9 +23,26 @@ func TestGetFreePort(t *testing.T) {
 	defer l.Close()
 }
 
-func TestGetFreePorts(t *testing.T) {
+func TestGetFreePortUDP(t *testing.T) {
+	port, err := GetFreePort("udp")
+	if err != nil {
+		t.Error(err)
+	}
+	if port == 0 {
+		t.Error("port == 0")
+	}
+
+	// Try to listen on the port
+	l, err := net.ListenPacket("udp", ":"+strconv.Itoa(port))
+	if err != nil {
+		t.Error(err)
+	}
+	defer l.Close()
+}
+
+func TestGetFreePortsTCP(t *testing.T) {
 	count := 3
-	ports, err := GetFreePorts(count)
+	ports, err := GetFreePorts("tcp", count)
 	if err != nil {
 		t.Error(err)
 	}
@@ -39,6 +56,29 @@ func TestGetFreePorts(t *testing.T) {
 
 		// Try to listen on the port
 		l, err := net.Listen("tcp", "localhost"+":"+strconv.Itoa(port))
+		if err != nil {
+			t.Error(err)
+		}
+		defer l.Close()
+	}
+}
+
+func TestGetFreePortsUDP(t *testing.T) {
+	count := 3
+	ports, err := GetFreePorts("udp", count)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(ports) == 0 {
+		t.Error("len(ports) == 0")
+	}
+	for _, port := range ports {
+		if port == 0 {
+			t.Error("port == 0")
+		}
+
+		// Try to listen on the port
+		l, err := net.ListenPacket("udp", ":"+strconv.Itoa(port))
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
Adds support for getting free ports available for UDP connections. Added additional tests to listen on UDP.

Kept the previous interface for backwards compatibility, so `GetFreePorts` still finds ports only on TCP. Added a new function `GetFreePortsForProtocol`, which takes the protocol parameter as a string (Default is to use TCP).