### PR TITLE
Add Builds for `arm64`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,7 @@ builds:
     goarch:
       - amd64
       - "386"
+      - arm64
     goarm:
       - "6"
     main: ./cmd/freeport


### PR DESCRIPTION
This PR adds builds for `arm64`. @phayes, can you merge this? This would prevent my team at NVIDIA from having to fork the repo and do our own builds. Thanks!