### PR TITLE
Replacing go get with go install in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ dpkg -i freeport_1.0.2_linux_amd64.deb
 #### Building From Source
 ```bash
 sudo apt-get install golang                    # Download go. Alternativly build from source: https://golang.org/doc/install/source
-go get github.com/phayes/freeport
+go install -v github.com/phayes/freeport@latest
 ```


### PR DESCRIPTION
Starting in Go 1.17, installing executables with go get is deprecated. go install is the recommended way of installing executables - https://go.dev/doc/go-get-install-deprecation

This merge request adds command that uses go install to install freeport as a command and works across Go versions.